### PR TITLE
drafter: fixed install step for head (drafter 4)

### DIFF
--- a/Formula/drafter.rb
+++ b/Formula/drafter.rb
@@ -19,10 +19,11 @@ class Drafter < Formula
     if build.head?
       system "cmake", ".", *std_cmake_args
       system "make"
+      system "make", "install"
     else
       system "./configure"
+      system "make", "install", "DESTDIR=#{prefix}"
     end
-    system "make", "install", "DESTDIR=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
Drafter 4 (head) introduced CMake in its build system. Because CMake manages
its own install prefix, passing it via DESTDIR to `make` once more
duplicates the prefix path; leading to a wrong install.
  This commit ensures DESTDIR is only set when not installing
drafter 4 (head).
